### PR TITLE
feat(QuizElapsedTime): add elapsed time to quiz

### DIFF
--- a/youtube-gpt-client/package-lock.json
+++ b/youtube-gpt-client/package-lock.json
@@ -26,7 +26,8 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-i18next": "^13.2.2",
-        "typescript": "5.2.2"
+        "typescript": "5.2.2",
+        "use-elapsed-time": "^3.0.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -5331,6 +5332,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-elapsed-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/use-elapsed-time/-/use-elapsed-time-3.0.4.tgz",
+      "integrity": "sha512-q9b9j0K1SfsX2B9vzfRYkNyn2kBV5YBh9oJ/+XnIPKFjLbjvnF2PnJ/08HWPfCKKBWGz8d1qAfmXiYxWAseklw==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/use-sidecar": {

--- a/youtube-gpt-client/package.json
+++ b/youtube-gpt-client/package.json
@@ -27,6 +27,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-i18next": "^13.2.2",
-    "typescript": "5.2.2"
+    "typescript": "5.2.2",
+    "use-elapsed-time": "^3.0.4"
   }
 }

--- a/youtube-gpt-client/public/locales/en/quiz.json
+++ b/youtube-gpt-client/public/locales/en/quiz.json
@@ -7,6 +7,7 @@
     "unlucky": "Unlucky!",
     "subTitle": "You have scored {{score}} of {{questions}}",
     "subTitleFailure": "It looks like that was a really hard topic.\nWhat about trying it again?",
+    "time": "Time: {{time}}",
     "shareResults": "Share Results",
     "tryAgain": "Try another video"
   }

--- a/youtube-gpt-client/public/locales/es/quiz.json
+++ b/youtube-gpt-client/public/locales/es/quiz.json
@@ -7,6 +7,7 @@
     "unlucky": "Desafortunado!",
     "subTitle": "Has puntuado {{score}} de {{questions}}",
     "subTitleFailure": "Parece que fue un tema realmente difícil.\n¿Qué tal si lo intentamos de nuevo?",
+    "time": "Tiempo: {{time}}",
     "shareResults": "Compartir Resultados",
     "tryAgain": "Prueba con otro vídeo"
   }

--- a/youtube-gpt-client/src/components/quiz/index.tsx
+++ b/youtube-gpt-client/src/components/quiz/index.tsx
@@ -8,18 +8,45 @@ import {
   Flex,
   Text,
 } from '@chakra-ui/react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import QuizItem from './quizItem';
 import { getQuizQuestions } from '@/services/quiz';
 import { useRouter } from 'next/router';
+import { useElapsedTime } from 'use-elapsed-time';
 
 const Quiz = () => {
   const router = useRouter();
   const quizQuestions = getQuizQuestions();
   const [quizStatus, setQuizStatus] = useState<QuestionResponse[]>([]);
   const [tabIndex, setTabIndex] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const { elapsedTime } = useElapsedTime({ isPlaying });
+
+  const startTimer = () => {
+    if (!isPlaying) {
+      setIsPlaying(true);
+    }
+  };
+
+  const stopTimer = () => {
+    setIsPlaying(false);
+  };
+
+  useEffect(() => {
+    startTimer();
+  });
+
+  function formatElapsedTimer(elapsed: number) {
+    const seconds = Math.floor(elapsed % 60);
+    const minutes = Math.floor((elapsed % 3600) / 60);
+
+    return `${minutes < 10 ? '0' : ''}${minutes}:${
+      seconds < 10 ? '0' : ''
+    }${seconds} `;
+  }
 
   const displayResults = (results: QuestionResponse[]) => {
+    stopTimer();
     router.push(
       {
         pathname: '/quiz/result',
@@ -27,6 +54,7 @@ const Quiz = () => {
           questions: quizQuestions.length,
           correct: results.filter((w) => w.response).length,
           wrong: results.filter((w) => w.response !== true).length,
+          time: formatElapsedTimer(elapsedTime),
         },
       },
       '/quiz/result',
@@ -69,7 +97,18 @@ const Quiz = () => {
   };
 
   return (
-    <>
+    <Flex flexDirection="column" alignItems="center" width="100%">
+      <Flex
+        width={['100%', '800px']}
+        justifyContent="end"
+        color="#0E6CCB"
+        fontSize={['20px', '30px']}
+        marginBottom={['20px', '0px']}
+        fontWeight="600"
+        paddingRight="20px"
+      >
+        {formatElapsedTimer(elapsedTime)}
+      </Flex>
       <Tabs
         variant="soft-rounded"
         width={['100%', '800px']}
@@ -124,7 +163,7 @@ const Quiz = () => {
           ))}
         </TabPanels>
       </Tabs>
-    </>
+    </Flex>
   );
 };
 

--- a/youtube-gpt-client/src/components/quiz/result/index.tsx
+++ b/youtube-gpt-client/src/components/quiz/result/index.tsx
@@ -5,7 +5,7 @@ import { QuizPageResultProps } from '@/types';
 import { Flex, Text, Button } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
 
-const QuizResult = ({ questions, correct }: QuizPageResultProps) => {
+const QuizResult = ({ questions, correct, time }: QuizPageResultProps) => {
   const { t } = useTranslation('quiz');
   const userHasCorrectAnswer =
     questions !== undefined && correct !== undefined && correct > 0;
@@ -44,7 +44,7 @@ const QuizResult = ({ questions, correct }: QuizPageResultProps) => {
     return <></>;
   };
   return (
-    <Flex flexDirection="column" gap="23px" alignItems="center">
+    <Flex flexDirection="column" gap="23px" alignItems="center" margin="0 auto">
       <Text
         textAlign="center"
         fontWeight="700"
@@ -61,8 +61,7 @@ const QuizResult = ({ questions, correct }: QuizPageResultProps) => {
         textAlign="center"
         fontWeight="500"
         fontSize="20px"
-        lineHeight="45px"
-        letterSpacing="0.3"
+        lineHeight="30px"
         whiteSpace="pre-line"
       >
         {userHasCorrectAnswer
@@ -72,10 +71,21 @@ const QuizResult = ({ questions, correct }: QuizPageResultProps) => {
             })
           : t('result.subTitleFailure')}
       </Text>
+      <Text
+        textAlign="center"
+        fontWeight="500"
+        fontSize="20px"
+        lineHeight="30px"
+        marginBottom="15px"
+      >
+        {t('result.time', {
+          time,
+        })}
+      </Text>
       <Flex flexDirection="row" gap="16px" alignItems="center">
         {userHasCorrectAnswer && (
           <Button
-            w="145px"
+            minW="145px"
             fontSize="14px"
             color="#5893CE"
             bg="rgba(0, 122, 255, 0.10)"
@@ -85,7 +95,7 @@ const QuizResult = ({ questions, correct }: QuizPageResultProps) => {
           </Button>
         )}
         <Button
-          w="145px"
+          minW="145px"
           fontSize="14px"
           bg="#5893CE"
           borderRadius="8px"

--- a/youtube-gpt-client/src/pages/quiz/result.tsx
+++ b/youtube-gpt-client/src/pages/quiz/result.tsx
@@ -4,13 +4,18 @@ import { GetServerSideProps } from 'next';
 import QuizResult from '@/components/quiz/result';
 import { QuizPageResultProps } from '@/types';
 
-const QuizPage = ({ questions, correct, wrong }: QuizPageResultProps) => {
+const QuizPage = ({ questions, correct, wrong, time }: QuizPageResultProps) => {
   return (
     <>
       <Head>
         <title>Youtube GPT - Quiz</title>
       </Head>
-      <QuizResult questions={questions} correct={correct} wrong={wrong} />
+      <QuizResult
+        questions={questions}
+        correct={correct}
+        wrong={wrong}
+        time={time}
+      />
     </>
   );
 };
@@ -19,9 +24,8 @@ export default QuizPage;
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   let { locale } = context;
-  const { questions, correct, wrong } = context.query;
-
-  if (!questions || !correct || !wrong) {
+  const { questions, correct, wrong, time } = context.query;
+  if (!questions || !correct || !wrong || !time) {
     return {
       redirect: {
         permanent: false,

--- a/youtube-gpt-client/src/services/quiz.ts
+++ b/youtube-gpt-client/src/services/quiz.ts
@@ -74,6 +74,31 @@ export const getQuizQuestions = () => {
         c: false,
       },
     ]
+  },
+  {
+    q: "Another Cool Question?",
+    as: [
+      {
+        a: "Super cool right answer",
+        c: true,
+      },
+      {
+        a: "Super cool wrong answer",
+        c: false,
+      },
+      {
+        a: "Super cool wrong answer",
+        c: false,
+      },
+      {
+        a: "Super cool wrong answer",
+        c: false,
+      },
+      {
+        a: "Super cool wrong answer",
+        c: false,
+      },
+    ]
   }];
 
   return questions;

--- a/youtube-gpt-client/src/types/index.ts
+++ b/youtube-gpt-client/src/types/index.ts
@@ -43,6 +43,7 @@ export interface QuizPageResultProps {
   questions?: number;
   correct?: number;
   wrong?: number;
+  time?:string;
 }
 
 export type SummaryData = {


### PR DESCRIPTION
# Description

This PR add to the quiz page the tracking elapsed time feature using the "use-elapsed-time" package and some ui improvements.

## Summary:
- UI Corrections
- Display elapsed time
- Add "use-elapsed-time" package to handle the elapsed time inside the quiz page

## Demo

Desktop:

https://github.com/nandoramos/youtube-gpt/assets/106548895/d3b14e46-892b-49fb-95a1-c0cdba7f98c3

Mobile:

https://github.com/nandoramos/youtube-gpt/assets/106548895/2fa1173e-f6ee-4584-87bc-e1a3043a0946

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
